### PR TITLE
fix put_start_and_end_on method in 3d

### DIFF
--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -830,7 +830,6 @@ class Mobject(object):
         return self
 
     def put_start_and_end_on(self, start, end):
-        # TODO, this doesn't currently work in 3d
         curr_start, curr_end = self.get_start_and_end()
         curr_vect = curr_end - curr_start
         if np.all(curr_vect == 0):
@@ -838,13 +837,16 @@ class Mobject(object):
         target_vect = end - start
         self.scale(
             get_norm(target_vect) / get_norm(curr_vect),
-            about_point=curr_start,
+            about_point = curr_start,
         )
         self.rotate(
             angle_of_vector(target_vect) - angle_of_vector(curr_vect),
-            about_point=curr_start
         )
-        self.shift(start - curr_start)
+        self.rotate(
+            math.atan2(target_vect[2], np.sqrt(target_vect[0]**2 + target_vect[1]**2)) - math.atan2(curr_vect[2], np.sqrt(curr_vect[0]**2 + curr_vect[1]**2)), 
+            axis = np.array([-target_vect[1], target_vect[0], 0]),
+        )
+        self.shift(start - self.get_start())
         return self
 
     # Color functions


### PR DESCRIPTION
## Proposed changes
I added another rotation to make `put_start_and_end_on` work in 3d.
## Test
Here are some tests on `Line`s and `Arc`s

https://user-images.githubusercontent.com/86904416/128202220-02f87081-9286-41c6-8880-01d081bec8da.mp4

https://user-images.githubusercontent.com/86904416/128201694-74ca92bf-31ab-41cc-af17-25b5d44ce1a1.mp4

